### PR TITLE
fix(delete): Correct value for branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ All event messages will have these elements:
 
 ### Delete
 
-![Delete](https://user-images.githubusercontent.com/5962998/104859330-f1661700-58fa-11eb-9e23-536d8ed443cd.png)
+![Delete](https://user-images.githubusercontent.com/5962998/104859938-0ba1f400-58ff-11eb-8645-9c5cedac4bde.png)
 
-1. Branch Name - Also link to the branch.
+1. Branch Name
 
 ## Usage
 

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -105,11 +105,8 @@ const getMessage = () => {
         return null;
       }
 
-      const pre = 'refs/heads/';
-      const branchName = context.ref.substring(pre.length);
-      const branchUrl = `${context.payload.repository.html_url}/tree/${branchName}`;
-
-      return `Workflow <${runUrl}|${process.env.GITHUB_WORKFLOW}> for Deletion of Branch <${branchUrl}|${branchName}>`;
+      const branchName = context.payload.ref;
+      return `Workflow <${runUrl}|${process.env.GITHUB_WORKFLOW}> for Deletion of Branch \`${branchName}\``;
     }
 
     default:


### PR DESCRIPTION
The message was showing the head branch instead of the branch deleted.

Also removed the link (cause well umm) there's no branch anymore :D